### PR TITLE
Avoid unused warnings

### DIFF
--- a/speculation_barrier.h
+++ b/speculation_barrier.h
@@ -44,6 +44,13 @@
   (__builtin_load_no_speculate (__ptr, __low, __high, __failval, __cmpptr))
 
 #else
+
+#ifdef __GNUC__
+#define __UNUSED __attribute__((unused))
+#else
+#define __UNUSED
+#endif
+
 #ifdef __aarch64__
 
 #define __load_no_speculate1(__ptr, __low, __high, __failval,		\
@@ -135,7 +142,7 @@
     default:								\
       {									\
         char __static_assert_no_speculate_load_size_too_big 		\
-		[sizeof (__nl_val) > 8 ? -1 : 1];			\
+		[sizeof (__nl_val) > 8 ? -1 : 1] __UNUSED;		\
         break;								\
       }									\
  }									\
@@ -246,7 +253,6 @@
      unsigned long before handing it to __builtin_constant_p to	\
      ensure that clang/llvm correctly detects NULL as a constant if it	\
      is defined as (void*) 0.  */					\
-   __typeof__ (__ptr) __tmp_ptr;					\
   if (__builtin_constant_p ((unsigned long)__high)			\
       && __high == ((void *)0))						\
     {									\
@@ -470,7 +476,7 @@
     default:								\
       {									\
         char __static_assert_no_speculate_load_size_too_big 		\
-		[sizeof (__nl_val) > 8 ? -1 : 1];			\
+		[sizeof (__nl_val) > 8 ? -1 : 1] __UNUSED;		\
         break;								\
       }									\
  }									\


### PR DESCRIPTION
__tmp_ptr is not used at all; remove it to avoid a compiler warning.

Similarly, __static_assert_no_speculate_load_size_too_big is not
referenced anywhere. Tag it with __attribute__(("unused")) so that GCC
won't complain.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>